### PR TITLE
migrating to boxo SDK from archived go-ipfs libraries

### DIFF
--- a/init.go
+++ b/init.go
@@ -335,7 +335,7 @@ func IdentityConfig(out io.Writer, nbits int, keyType string, importKey string, 
 	if err != nil {
 		return ident, err
 	}
-	ident.PeerID = id.Pretty()
+	ident.PeerID = id.String()
 	fmt.Fprintf(out, "peer identity: %s\n", ident.PeerID)
 	return ident, nil
 }

--- a/routing.go
+++ b/routing.go
@@ -15,6 +15,8 @@ type Routing struct {
 	// When "custom" is set, user-provided Routing.Routers is used.
 	Type *OptionalString `json:",omitempty"`
 
+	AcceleratedDHTClient bool
+
 	Routers Routers
 
 	Methods Methods

--- a/swarm.go
+++ b/swarm.go
@@ -144,7 +144,7 @@ type ConnMgr struct {
 type ResourceMgr struct {
 	// Enables the Network Resource Manager feature, default to on.
 	Enabled Flag               `json:",omitempty"`
-	Limits  *rcmgr.LimitConfig `json:",omitempty"`
+	Limits  *rcmgr.PartialLimitConfig `json:",omitempty"`
 
 	MaxMemory          *OptionalString  `json:",omitempty"`
 	MaxFileDescriptors *OptionalInteger `json:",omitempty"`


### PR DESCRIPTION
As part of the IPFS SDK dependencies migration to boxo, this update is necessary to move to boxo SDK for BTFS. I'll be doing other Pull Request in several BTFS repos to safely move to boxo and support newer golang releases